### PR TITLE
Fix dynamic=NO not working

### DIFF
--- a/Examples/FXBlurViewExample/FXBlurViewExample/ViewController.m
+++ b/Examples/FXBlurViewExample/FXBlurViewExample/ViewController.m
@@ -20,21 +20,9 @@
 
 @implementation ViewController
 
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-    
-    self.blurView.dynamic = NO;
-}
-
 - (IBAction)updateBlur:(UISlider *)slider
 {
     self.blurView.blurRadius = slider.value;
-}
-
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
-{
-    [self.blurView setNeedsDisplay];
 }
 
 @end


### PR DESCRIPTION
I couldn't figure out what `setNeedsRedraw` means from README.md,
but when I tried setNeedsDisplay with dynamic=NO, the layer.content didn't update,
so here's my fix. Please check!
