### PR TITLE
Added support for tint color and saturation

### DIFF
--- a/FXBlurView/FXBlurView.h
+++ b/FXBlurView/FXBlurView.h
@@ -51,7 +51,7 @@
 @property (nonatomic, assign) NSUInteger iterations;
 @property (nonatomic, assign) NSTimeInterval updateInterval;
 @property (nonatomic, assign) CGFloat blurRadius;
-@property (nonatomic, copy) UIColor *tintColor;
+@property (nonatomic, assign) CGFloat backgroundAlpha;
 @property (nonatomic, assign) CGFloat saturationDeltaFactor;
 
 @end


### PR DESCRIPTION
Apple's use of blur usually includes two other effects:

1) Tint color. You'll notice their nav bars / tab bars / etc are usually mostly white, with just the strong colors showing through. Current implementation leads the view to always be the color of the view behind it. ![example change](https://f.cloud.github.com/assets/171163/1059697/d1c5f806-11a0-11e3-8f91-a34d485fc122.jpg) Forked implementation allows for match to Apple's look of the toolbar/header in Maps.

2) Over-saturation. Apple saturates the colors they show through.

The saturation leads to a performance hit, but left I that optional for the user, disabled by default. Saturation code pulled from Apple's imageeffect demo from WWDC 2013.
