### PR TITLE
Compiler warnings has been suppressed.

### DIFF
--- a/FXBlurView/FXBlurView.h
+++ b/FXBlurView/FXBlurView.h
@@ -48,11 +48,14 @@
 + (void)setUpdatesEnabled;
 + (void)setUpdatesDisabled;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-property-synthesis"
 @property (nonatomic, getter = isBlurEnabled) BOOL blurEnabled;
 @property (nonatomic, getter = isDynamic) BOOL dynamic;
 @property (nonatomic, assign) NSUInteger iterations;
 @property (nonatomic, assign) NSTimeInterval updateInterval;
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, strong) UIColor *tintColor;
+#pragma clang diagnostic pop
 
 @end

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -114,22 +114,28 @@
 
 @interface FXBlurScheduler : NSObject
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-property-synthesis"
 @property (nonatomic, strong) NSMutableArray *views;
 @property (nonatomic, assign) NSInteger viewIndex;
 @property (nonatomic, assign) NSInteger updatesEnabled;
 @property (nonatomic, assign) BOOL blurEnabled;
 @property (nonatomic, assign) BOOL updating;
+#pragma clang diagnostic pop
 
 @end
 
 
 @interface FXBlurView ()
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-missing-property-synthesis"
 @property (nonatomic, assign) BOOL iterationsSet;
 @property (nonatomic, assign) BOOL blurRadiusSet;
 @property (nonatomic, assign) BOOL dynamicSet;
 @property (nonatomic, assign) BOOL blurEnabledSet;
 @property (nonatomic, strong) NSDate *lastUpdate;
+#pragma clang diagnostic pop
 
 - (UIImage *)snapshotOfSuperview:(UIView *)superview;
 


### PR DESCRIPTION
Compiler warnings ("Auto property synthesis is synthesizing property not explicitly synthesized") has been suppressed.
