### PR TITLE
Allowed to be compiled against iOS 6 SDK

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -280,6 +280,7 @@
     if (!_blurEnabledSet) _blurEnabled = YES;
     self.updateInterval = _updateInterval;
     
+#ifdef __IPHONE_7_0
     unsigned int numberOfMethods;
     Method *methods = class_copyMethodList([UIView class], &numberOfMethods);
     for (unsigned int i = 0; i < numberOfMethods; i++)
@@ -291,6 +292,7 @@
         }
     }
     free(methods);
+#endif
 }
 
 - (id)initWithFrame:(CGRect)frame


### PR DESCRIPTION
Wrapped the call to `super.tintColor` in `#ifdef __IPHONE_7_0` to allow this class to be compiled using the iOS 6 SDK.
