### PR TITLE
snapshot appropriate area of underlying view

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -428,8 +428,8 @@
 
 - (UIImage *)snapshotOfUnderlyingView
 {
-    CGRect bounds = self.bounds;
     __strong UIView *underlyingView = self.underlyingView;
+    CGRect bounds = [underlyingView convertRect:self.bounds fromView:self];
     if (_dynamic && self.layer.presentationLayer)
     {
         //in dynamic mode, use presentation layer instead of model


### PR DESCRIPTION
When dynamic = NO, we need to be sure to snapshot the appropriate bounds of the underlying view so the blur matches what is directly behind the blur view.

The issue is apparent in the Basic Example. Disabling dynamic updates using the switch should not change the blur, but it does because the new snapshot is taken with bounds origin (0,0).
