### PR TITLE
Using UIColor alpha and changing blend modes

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -101,8 +101,8 @@
     //apply tint
     if (tintColor && CGColorGetAlpha(tintColor.CGColor) > 0.0f)
     {
-        CGContextSetFillColorWithColor(ctx, [tintColor colorWithAlphaComponent:0.25].CGColor);
-        CGContextSetBlendMode(ctx, kCGBlendModePlusLighter);
+        CGContextSetFillColorWithColor(ctx, [tintColor colorWithAlphaComponent:CGColorGetAlpha(tintColor.CGColor)].CGColor);
+        CGContextSetBlendMode(ctx, kCGBlendModeNormal);
         CGContextFillRect(ctx, CGRectMake(0, 0, buffer1.width, buffer1.height));
     }
     


### PR DESCRIPTION
I needed to have a blur view that darkened the view below it.  I found that using kCGBlendModeNormal improved results across a range of colors and allowing the user to set the transparency in InterfaceBuilder helped get the effect we needed.