### PR TITLE
Fix for Swift and more flexible tint

### DIFF
--- a/FXBlurView/FXBlurView.h
+++ b/FXBlurView/FXBlurView.h
@@ -50,6 +50,7 @@
 @interface UIImage (FXBlurView)
 
 - (UIImage *)blurredImageWithRadius:(CGFloat)radius iterations:(NSUInteger)iterations tintColor:(UIColor *)tintColor;
+- (UIImage *)blurredImageWithRadius:(CGFloat)radius iterations:(NSUInteger)iterations tintColor:(UIColor *)tintColor tintBlendMode:(CGBlendMode)tintBlendMode;
 
 @end
 
@@ -66,6 +67,7 @@
 @property (nonatomic, assign) NSTimeInterval updateInterval;
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, strong) UIColor *tintColor;
+@property (nonatomic, assign) CGBlendMode tintBlendMode;
 @property (nonatomic, weak_ref) UIView *underlyingView;
 
 - (void)updateAsynchronously:(BOOL)async completion:(void (^)())completion;

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -51,7 +51,11 @@
 
 @implementation UIImage (FXBlurView)
 
-- (UIImage *)blurredImageWithRadius:(CGFloat)radius iterations:(NSUInteger)iterations tintColor:(UIColor *)tintColor
+- (UIImage *)blurredImageWithRadius:(CGFloat)radius iterations:(NSUInteger)iterations tintColor:(UIColor *)tintColor {
+    return [self blurredImageWithRadius:radius iterations:iterations tintColor:tintColor tintBlendMode:kCGBlendModeLighten];
+}
+
+- (UIImage *)blurredImageWithRadius:(CGFloat)radius iterations:(NSUInteger)iterations tintColor:(UIColor *)tintColor tintBlendMode:(CGBlendMode)tintBlendMode
 {
     //image must be nonzero size
     if (floorf(self.size.width) * floorf(self.size.height) <= 0.0f) return self;
@@ -102,8 +106,8 @@
     //apply tint
     if (tintColor && CGColorGetAlpha(tintColor.CGColor) > 0.0f)
     {
-        CGContextSetFillColorWithColor(ctx, [tintColor colorWithAlphaComponent:0.25].CGColor);
-        CGContextSetBlendMode(ctx, kCGBlendModePlusLighter);
+        CGContextSetFillColorWithColor(ctx, tintColor.CGColor);
+        CGContextSetBlendMode(ctx, tintBlendMode);
         CGContextFillRect(ctx, CGRectMake(0, 0, buffer1.width, buffer1.height));
     }
     
@@ -159,6 +163,7 @@
 @property (nonatomic, assign) BOOL blurRadiusSet;
 @property (nonatomic, assign) BOOL dynamicSet;
 @property (nonatomic, assign) BOOL blurEnabledSet;
+@property (nonatomic, assign) BOOL tintBlendModeSet;
 @property (nonatomic, strong) NSDate *lastUpdate;
 
 - (UIImage *)snapshotOfUnderlyingView;
@@ -309,6 +314,7 @@
     if (!_blurRadiusSet) [self blurLayer].blurRadius = 40;
     if (!_dynamicSet) _dynamic = YES;
     if (!_blurEnabledSet) _blurEnabled = YES;
+    if(!_tintBlendModeSet) _tintBlendMode = kCGBlendModeLighten;
     self.updateInterval = _updateInterval;
     self.layer.magnificationFilter = @"linear"; // kCAFilterLinear
     
@@ -427,6 +433,12 @@
 - (void)setTintColor:(UIColor *)tintColor
 {
     _tintColor = tintColor;
+    [self setNeedsDisplay];
+}
+
+- (void)setTintBlendMode:(CGBlendMode)tintBlendMode {
+    _tintBlendModeSet = YES;
+    _tintBlendMode = tintBlendMode;
     [self setNeedsDisplay];
 }
 
@@ -573,7 +585,8 @@
 {
     return [snapshot blurredImageWithRadius:blurRadius
                                  iterations:self.iterations
-                                  tintColor:self.tintColor];
+                                  tintColor:self.tintColor
+                              tintBlendMode:self.tintBlendMode];
 }
 
 - (void)setLayerContents:(UIImage *)image


### PR DESCRIPTION
Two commits here, the first prevents an issue with the Accelerate framework when importing FXBlurView into the Swift bridging header, the second provides more flexibility defining a tint colour.  I'm not sure why you had a fixed tint alpha previously, but I needed to be able to alter the blend mode and alpha to get the effect I was looking for, so I removed the fixed alpha and added a blend mode property.  Merge as you wish.

Cheers!
