### PR TITLE
fix console error on iOS8 issue #44

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -94,7 +94,7 @@
     //create image context from buffer
     CGContextRef ctx = CGBitmapContextCreate(buffer1.data, buffer1.width, buffer1.height,
                                              8, buffer1.rowBytes, CGImageGetColorSpace(imageRef),
-                                             CGImageGetBitmapInfo(imageRef));
+                                             (CGBitmapInfo)kCGImageAlphaNoneSkipLast);
     
     //apply tint
     if (tintColor && CGColorGetAlpha(tintColor.CGColor) > 0.0f)


### PR DESCRIPTION
I've fix issue #44 
Check it out my code and Please merge my code.
check this page(http://iphonedevsdk.com/forum/iphone-sdk-development/31239-cgbitmapcontextcreate-unsupported-parameter-combination-is-drivin-me-nuts.html)

see small duck's comment.

This is an old message, but I thought I'd update it with what I've found since it was the first hit when I googled: CGBitmapContextCreate "unsupported parameter combination" kCGImageAlphaLast

Apple developer Q&A 1037 seems to say that CGBitmapContextCreate doesn't support kCGImageAlphaLast, but instead only kCGImageAlphaPremultipliedLast. What I'm going to do is test the original bitmap info first and if it's kCGImageAlphaLast, instead drop down to kCGImageAlphaNoneSkipLast, essentially losing the alpha.

