### PR TITLE
fix error "<Error>: CGContextRestoreGState: invalid context 0x0. This is...

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -105,6 +105,7 @@
     }
     
     //create image from context
+    UIGraphicsPushContext(ctx);
     imageRef = CGBitmapContextCreateImage(ctx);
     UIImage *image = [UIImage imageWithCGImage:imageRef scale:self.scale orientation:self.imageOrientation];
     CGImageRelease(imageRef);


### PR DESCRIPTION
fix error "<Error>: CGContextRestoreGState: invalid context 0x0. This is a serious error. This application, or a library it uses, is using an invalid context  and is thereby contributing to an overall degradation of system stability and reliability. This notice is a courtesy: please fix this problem. It will become a fatal error in an upcoming update."