### PR TITLE
Fix #79 - renderInContext crash on iOS 8

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -544,6 +544,19 @@
     return snapshot;
 }
 
+- (NSArray *)hideEmptyLayers:(CALayer *)layer
+{
+    NSMutableArray *layers = [NSMutableArray array];
+    if (CGRectIsEmpty(layer.bounds)) {
+        layer.hidden = YES;
+        [layers addObject:layer];
+    }
+    for (CALayer *sublayer in layer.sublayers) {
+        [layers addObjectsFromArray:[self hideEmptyLayers:sublayer]];
+    }
+    return layers;
+}
+
 - (NSArray *)prepareUnderlyingViewForSnapshot
 {
     __strong CALayer *blurlayer = [self blurLayer];
@@ -566,6 +579,10 @@
             }
         }
     }
+
+    // Also hide any sublayers with empty bounds to prevent a crash on iOS 8
+    [layers addObjectsFromArray:[self hideEmptyLayers:underlyingLayer]];
+
     return layers;
 }
 


### PR DESCRIPTION
If any of the sublayers of `underlyingLayer` has empty bounds, `renderInContext` crashes on iOS 8 (but does not on iOS 8). This change hides those layers with empty bounds and un-hides them back during the restore process that already happens.

This should fix issue #79 