### PR TITLE
Prevent crash upon malloc returning NULL

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -80,7 +80,7 @@
     buffer2.data = malloc(bytes);
 
     if (NULL == buffer1.data || NULL == buffer2.data) {
-      return nil;
+       return nil;
     }
 
     //create temp buffer
@@ -88,7 +88,7 @@
                                                                  NULL, kvImageEdgeExtend + kvImageGetTempBufferSize));
 
     if (NULL == tempBuffer) {
-      return nil;
+        return nil;
     }
 
     //copy image data

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -82,7 +82,7 @@
     if (NULL == buffer1.data || NULL == buffer2.data) {
         free(buffer1.data);
         free(buffer2.data);
-        return nil;
+        return self;
     }
 
     //create temp buffer
@@ -93,7 +93,7 @@
     CGDataProviderRef provider = CGImageGetDataProvider(imageRef);
     CFDataRef dataSource = CGDataProviderCopyData(provider);
     if (NULL == dataSource) {
-      return nil;
+      return self;
     }
     const UInt8 *dataSourceData = CFDataGetBytePtr(dataSource);
     memcpy(buffer1.data, dataSourceData, bytes);

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -78,18 +78,16 @@
     size_t bytes = buffer1.rowBytes * buffer1.height;
     buffer1.data = malloc(bytes);
     buffer2.data = malloc(bytes);
-
+  
     if (NULL == buffer1.data || NULL == buffer2.data) {
-       return nil;
+        free(buffer1.data);
+        free(buffer2.data);
+        return nil;
     }
 
     //create temp buffer
     void *tempBuffer = malloc((size_t)vImageBoxConvolve_ARGB8888(&buffer1, &buffer2, NULL, 0, 0, boxSize, boxSize,
                                                                  NULL, kvImageEdgeExtend + kvImageGetTempBufferSize));
-
-    if (NULL == tempBuffer) {
-        return nil;
-    }
 
     //copy image data
     CFDataRef dataSource = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -79,9 +79,17 @@
     buffer1.data = malloc(bytes);
     buffer2.data = malloc(bytes);
 
+    if (NULL == buffer1.data || NULL == buffer2.data) {
+      return nil;
+    }
+
     //create temp buffer
     void *tempBuffer = malloc((size_t)vImageBoxConvolve_ARGB8888(&buffer1, &buffer2, NULL, 0, 0, boxSize, boxSize,
                                                                  NULL, kvImageEdgeExtend + kvImageGetTempBufferSize));
+
+    if (NULL == tempBuffer) {
+      return nil;
+    }
 
     //copy image data
     CFDataRef dataSource = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -79,7 +79,8 @@
     buffer1.data = malloc(bytes);
     buffer2.data = malloc(bytes);
   
-    if (NULL == buffer1.data || NULL == buffer2.data) {
+    if (NULL == buffer1.data || NULL == buffer2.data) 
+    {
         free(buffer1.data);
         free(buffer2.data);
         return self;
@@ -92,8 +93,9 @@
     //copy image data
     CGDataProviderRef provider = CGImageGetDataProvider(imageRef);
     CFDataRef dataSource = CGDataProviderCopyData(provider);
-    if (NULL == dataSource) {
-      return self;
+    if (NULL == dataSource) 
+    {
+        return self;
     }
     const UInt8 *dataSourceData = CFDataGetBytePtr(dataSource);
     CFIndex dataSourceLength = CFDataGetLength(dataSource);

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -90,11 +90,13 @@
                                                                  NULL, kvImageEdgeExtend + kvImageGetTempBufferSize));
 
     //copy image data
-    CFDataRef dataSource = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));
+    CGDataProviderRef provider = CGImageGetDataProvider(imageRef);
+    CFDataRef dataSource = CGDataProviderCopyData(provider);
     if (NULL == dataSource) {
       return nil;
     }
-    memcpy(buffer1.data, CFDataGetBytePtr(dataSource), bytes);
+    const UInt8 *dataSourceData = CFDataGetBytePtr(dataSource);
+    memcpy(buffer1.data, dataSourceData, bytes);
     CFRelease(dataSource);
 
     for (NSUInteger i = 0; i < iterations; i++)

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -96,7 +96,8 @@
       return self;
     }
     const UInt8 *dataSourceData = CFDataGetBytePtr(dataSource);
-    memcpy(buffer1.data, dataSourceData, bytes);
+    CFIndex dataSourceLength = CFDataGetLength(dataSource);
+    memcpy(buffer1.data, dataSourceData, MIN(bytes, dataSourceLength));
     CFRelease(dataSource);
 
     for (NSUInteger i = 0; i < iterations; i++)

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -91,6 +91,9 @@
 
     //copy image data
     CFDataRef dataSource = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));
+    if (NULL == dataSource) {
+      return nil;
+    }
     memcpy(buffer1.data, CFDataGetBytePtr(dataSource), bytes);
     CFRelease(dataSource);
 


### PR DESCRIPTION
We had a crash in production on line 94 with `EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000000` I can reproduce this by setting either `buffer1.data` and/or `buffer2.data` to `NULL` (`malloc()` will naturally return NULL if the system is out of memory)

This fixes said issue. 
