### PR TITLE
The hidden sublayers are displayed after snapshot

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -630,7 +630,7 @@
 - (NSArray *)hideEmptyLayers:(CALayer *)layer
 {
     NSMutableArray *layers = [NSMutableArray array];
-    if (CGRectIsEmpty(layer.bounds))
+    if (CGRectIsEmpty(layer.bounds) && !layer.isHidden)
     {
         layer.hidden = YES;
         [layers addObject:layer];


### PR DESCRIPTION
if a sublayer with empty size was hidden, his 'hidden' property was set to YES after snapshot.